### PR TITLE
Added .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+---
+BasedOnStyle: Google
+AlignAfterOpenBracket: AlwaysBreak
+AlignOperands: 'true'
+AllowAllArgumentsOnNextLine: 'false'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBinaryOperators: NonAssignment
+ExperimentalAutoDetectBinPacking: 'false'
+ReflowComments: 'false'
+
+...


### PR DESCRIPTION
Please test the style settings in this PR.

Should be used to automatically format the whole code base of RBDL.

Note: matrices need special guards to keep formatting (see https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code)