### PR TITLE
Add the function 'CalcZeroMomentPoint'

### DIFF
--- a/python/crbdl.pxd
+++ b/python/crbdl.pxd
@@ -703,7 +703,16 @@ cdef extern from "rbdl_loadmodel.cc":
            Model* model,
            bool floating_base,
            bool verbose)
+
+cdef extern from "rbdl/rbdl_utils.h" namespace "RigidBodyDynamics::Utils":
+    cdef void CalcZeroMomentPoint (Model& model,
+	    const VectorNd &q,
+	    const VectorNd &qdot,
+	    const VectorNd &qddot,
+ 	    Vector3d* zmp,
+	    const Vector3d &normal,
+	    const Vector3d &point,
+            bool update_kinematics)
      
-        
         
   

--- a/python/rbdl-wrapper.pyx
+++ b/python/rbdl-wrapper.pyx
@@ -2355,7 +2355,51 @@ def CalcCenterOfMass (Model model,
         del c_change_ang_momentum_ptr
 
     return cmass
-    
+
+def CalcZeroMomentPoint (Model model,
+        np.ndarray[double, ndim=1, mode="c"] q,
+        np.ndarray[double, ndim=1, mode="c"] qdot,
+        np.ndarray[double, ndim=1, mode="c"] qddot,
+        np.ndarray[double, ndim=1, mode="c"] zmp,
+        np.ndarray[double, ndim=1, mode="c"] normal=None,
+        np.ndarray[double, ndim=1, mode="c"] point=None,
+        update_kinematics=True):
+
+    cdef crbdl.Vector3d c_normal = crbdl.Vector3d()
+    cdef crbdl.Vector3d c_point = crbdl.Vector3d()
+
+    cdef crbdl.Vector3d* c_zmp_ptr# = crbdl.Vector3d()
+    c_zmp_ptr = new crbdl.Vector3d()
+
+    if normal is not None:
+        c_normal[0] = normal[0]
+        c_normal[1] = normal[1]
+        c_normal[2] = normal[2]
+    else:
+        c_normal[0] = 0
+        c_normal[1] = 0
+        c_normal[2] = 1
+
+    if point is not None:
+        c_point[0] = point[0]
+        c_point[1] = point[1]
+        c_point[2] = point[2]
+
+    crbdl.CalcZeroMomentPoint (
+            model.thisptr[0],
+            NumpyToVectorNd (q),
+            NumpyToVectorNd (qdot),
+            NumpyToVectorNd (qddot),
+            c_zmp_ptr,
+            c_normal,
+            c_point,
+            update_kinematics)
+
+    zmp[0] = c_zmp_ptr.data()[0]
+    zmp[1] = c_zmp_ptr.data()[1]
+    zmp[2] = c_zmp_ptr.data()[2]
+
+    return zmp
 
 ##############################
 #


### PR DESCRIPTION
As the issue #58, the function CalcZeroMomentPoint missed in this version.

Through the discussion with @ju6ge , successfully adding this function.

Co-Authored-By: Felix Richter <judge@felixrichter.tech>