### PR TITLE
Add API to update body inertial parameters at runtime

### DIFF
--- a/include/rbdl/Body.h
+++ b/include/rbdl/Body.h
@@ -199,7 +199,9 @@ struct RBDL_DLLAPI Body {
     LOG << "new_com  = " << new_com.transpose() << std::endl;
     LOG << "new_inertia  = " << std::endl << new_inertia << std::endl;
 
-    *this = Body (new_mass, new_com, new_inertia);
+    mMass = new_mass;
+    mCenterOfMass = new_com;
+    mInertia = new_inertia;
   }
 
   ~Body() {};

--- a/include/rbdl/Body.h
+++ b/include/rbdl/Body.h
@@ -317,6 +317,11 @@ struct RBDL_DLLAPI FixedBody {
 
     return fbody;
   }
+
+  Body toBody()
+  {
+    return Body(mMass, mCenterOfMass, mInertia);
+  }
 };
 
 }

--- a/include/rbdl/Body.h
+++ b/include/rbdl/Body.h
@@ -205,9 +205,7 @@ struct RBDL_DLLAPI Body {
     LOG << "new_com  = " << new_com.transpose() << std::endl;
     LOG << "new_inertia  = " << std::endl << new_inertia << std::endl;
 
-    mMass = new_mass;
-    mCenterOfMass = new_com;
-    mInertia = new_inertia;
+    *this = Body (new_mass, new_com, new_inertia);
   }
 
   /**
@@ -273,9 +271,7 @@ struct RBDL_DLLAPI Body {
         inertia_substracted - new_mass * Math::VectorCrossMatrix(new_com) *
                                   Math::VectorCrossMatrix(new_com).transpose();
 
-    mMass = new_mass;
-    mCenterOfMass = new_com;
-    mInertia = new_inertia;
+    *this = Body (new_mass, new_com, new_inertia);
   }
 
   ~Body() {};

--- a/include/rbdl/Body.h
+++ b/include/rbdl/Body.h
@@ -30,19 +30,13 @@ struct RBDL_DLLAPI Body {
     mMass (0.),
     mCenterOfMass (0., 0., 0.),
     mInertia (Math::Matrix3d::Zero()),
-    mIsVirtual (false),
-    mInitialMass(mMass),
-    mInitialCenterOfMass(mCenterOfMass),
-    mInitialInertia(mInertia)
+    mIsVirtual (false)
   { };
   Body(const Body &body) :
     mMass (body.mMass),
     mCenterOfMass (body.mCenterOfMass),
     mInertia (body.mInertia),
-    mIsVirtual (body.mIsVirtual),
-    mInitialMass(mMass),
-    mInitialCenterOfMass(mCenterOfMass),
-    mInitialInertia(mInertia)
+    mIsVirtual (body.mIsVirtual)
   {};
   Body& operator= (const Body &body)
   {
@@ -51,9 +45,6 @@ struct RBDL_DLLAPI Body {
       mInertia = body.mInertia;
       mCenterOfMass = body.mCenterOfMass;
       mIsVirtual = body.mIsVirtual;
-      mInitialMass = body.mInitialMass;
-      mInitialCenterOfMass = body.mInitialCenterOfMass;
-      mInitialInertia = body.mInitialInertia;
     }
 
     return *this;
@@ -75,16 +66,13 @@ struct RBDL_DLLAPI Body {
       const Math::Vector3d &gyration_radii) :
     mMass (mass),
     mCenterOfMass(com),
-    mIsVirtual (false),
-    mInitialMass(mMass),
-    mInitialCenterOfMass(mCenterOfMass)
+    mIsVirtual (false)
   {
     mInertia = Math::Matrix3d (
                  gyration_radii[0], 0., 0.,
                  0., gyration_radii[1], 0.,
                  0., 0., gyration_radii[2]
                );
-    mInitialInertia = mInertia;
   }
 
   /** \brief Constructs a body from mass, center of mass, and a 3x3 inertia matrix
@@ -104,10 +92,7 @@ struct RBDL_DLLAPI Body {
     mMass (mass),
     mCenterOfMass(com),
     mInertia (inertia_C),
-    mIsVirtual (false),
-    mInitialMass(mMass),
-    mInitialCenterOfMass(mCenterOfMass),
-    mInitialInertia(mInertia) { }
+    mIsVirtual (false) { }
 
   /**
    * @brief transformInertiaToBodyFrame transform the inertia of initial_body to the frame of a target_body
@@ -303,18 +288,6 @@ struct RBDL_DLLAPI Body {
   Math::Matrix3d mInertia;
 
   bool mIsVirtual;
-
-  /// The following members are used to save the original values of the Body and
-  /// are not updated when a fixed body is attached to this body
-  /// \brief The mass of the body not taking in account any fixed body attached to this
-  /// body
-  double mInitialMass;
-  /// \brief The position of the center of mass in body coordinates not taking in account
-  /// any fixed body attached to this body
-  Math::Vector3d mInitialCenterOfMass;
-  /// \brief Inertia matrix at the center of mass not taking in account any fixed body
-  /// attached to this body
-  Math::Matrix3d mInitialInertia;
 };
 
 /** \brief Keeps the information of a body and how it is attached to another body.

--- a/include/rbdl/Body.h
+++ b/include/rbdl/Body.h
@@ -30,13 +30,19 @@ struct RBDL_DLLAPI Body {
     mMass (0.),
     mCenterOfMass (0., 0., 0.),
     mInertia (Math::Matrix3d::Zero()),
-    mIsVirtual (false)
+    mIsVirtual (false),
+    mInitialMass(mMass),
+    mInitialCenterOfMass(mCenterOfMass),
+    mInitialInertia(mInertia)
   { };
   Body(const Body &body) :
     mMass (body.mMass),
     mCenterOfMass (body.mCenterOfMass),
     mInertia (body.mInertia),
-    mIsVirtual (body.mIsVirtual)
+    mIsVirtual (body.mIsVirtual),
+    mInitialMass(mMass),
+    mInitialCenterOfMass(mCenterOfMass),
+    mInitialInertia(mInertia)
   {};
   Body& operator= (const Body &body)
   {
@@ -45,6 +51,9 @@ struct RBDL_DLLAPI Body {
       mInertia = body.mInertia;
       mCenterOfMass = body.mCenterOfMass;
       mIsVirtual = body.mIsVirtual;
+      mInitialMass = body.mInitialMass;
+      mInitialCenterOfMass = body.mInitialCenterOfMass;
+      mInitialInertia = body.mInitialInertia;
     }
 
     return *this;
@@ -66,13 +75,16 @@ struct RBDL_DLLAPI Body {
       const Math::Vector3d &gyration_radii) :
     mMass (mass),
     mCenterOfMass(com),
-    mIsVirtual (false)
+    mIsVirtual (false),
+    mInitialMass(mMass),
+    mInitialCenterOfMass(mCenterOfMass)
   {
     mInertia = Math::Matrix3d (
                  gyration_radii[0], 0., 0.,
                  0., gyration_radii[1], 0.,
                  0., 0., gyration_radii[2]
                );
+    mInitialInertia = mInertia;
   }
 
   /** \brief Constructs a body from mass, center of mass, and a 3x3 inertia matrix
@@ -92,7 +104,10 @@ struct RBDL_DLLAPI Body {
     mMass (mass),
     mCenterOfMass(com),
     mInertia (inertia_C),
-    mIsVirtual (false) { }
+    mIsVirtual (false),
+    mInitialMass(mMass),
+    mInitialCenterOfMass(mCenterOfMass),
+    mInitialInertia(mInertia) { }
 
   /** \brief Joins inertial parameters of two bodies to create a composite
    * body.
@@ -197,6 +212,18 @@ struct RBDL_DLLAPI Body {
   Math::Matrix3d mInertia;
 
   bool mIsVirtual;
+
+  /// The following members are used to save the original values of the Body and
+  /// are not updated when a fixed body is attached to this body
+  /// \brief The mass of the body not taking in account any fixed body attached to this
+  /// body
+  double mInitialMass;
+  /// \brief The position of the center of mass in body coordinates not taking in account
+  /// any fixed body attached to this body
+  Math::Vector3d mInitialCenterOfMass;
+  /// \brief Inertia matrix at the center of mass not taking in account any fixed body
+  /// attached to this body
+  Math::Matrix3d mInitialInertia;
 };
 
 /** \brief Keeps the information of a body and how it is attached to another body.

--- a/include/rbdl/Model.h
+++ b/include/rbdl/Model.h
@@ -505,6 +505,41 @@ struct RBDL_DLLAPI Model {
    * @param id the id of the body to update
    */
   void updateInertiaMatrixForBody(const unsigned int id);
+
+  /**
+   * @brief setBodyMass Set the mass of a body and update the inertia matrix corresponding
+   * to this body in the model
+   * @param id the id of the body to update
+   * @param mass the new mass
+   */
+  void setBodyMass(const unsigned int id, const double mass);
+
+  /**
+   * @brief setBodyInertia Set the inertia of a body and update the inertia matrix
+   * corresponding to this body in the model
+   * @param id the id of the body to update
+   * @param inertia the new inertia matrix
+   */
+  void setBodyInertia(const unsigned int id, const Math::Matrix3d &inertia);
+
+  /**
+   * @brief setBodyCenterOfMass Set the center of mass of a body and update the inertia
+   * matrix corresponding to this body in the model
+   * @param id the id of the body to update
+   * @param com the new center of mass position
+   */
+  void setBodyCenterOfMass(const unsigned int id, const Math::Vector3d &com);
+
+  /**
+   * @brief setBodyInertialParameters Set the inertial parameters of a body and update
+   * the inertia matrix corresponding to this body in the model
+   * @param id the id of the body to update
+   * @param mass the new mass
+   * @param inertia the new inertia matrix
+   * @param com the new center of mass position
+   */
+  void setBodyInertialParameters(const unsigned int id, const double mass,
+                                 const Math::Matrix3d &inertia, const Math::Vector3d &com);
 };
 
 /** @} */

--- a/include/rbdl/Model.h
+++ b/include/rbdl/Model.h
@@ -496,6 +496,15 @@ struct RBDL_DLLAPI Model {
     Q[q_index + 2] = quat[2];
     Q[multdof3_w_index[i]] = quat[3];
   }
+
+
+  /**
+   * @brief updateInertiaMatrixForBody Update the inner inertia matrix (I and Ic)
+   * stored in the model for the given body id.
+   * To use when the inertia of a body have been updated manually
+   * @param id the id of the body to update
+   */
+  void updateInertiaMatrixForBody(const unsigned int id);
 };
 
 /** @} */

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -520,8 +520,8 @@ void Model::updateInertiaMatrixForBody(const unsigned int id)
   Math::SpatialRigidBodyInertia rbi =
       Math::SpatialRigidBodyInertia::createFromMassComInertiaC(
           body.mMass, body.mCenterOfMass, body.mInertia);
-  Ic[id] = rbi;
-  I[id] = rbi;
+  Ic[body_id] = rbi;
+  I[body_id] = rbi;
 }
 
 
@@ -529,7 +529,15 @@ void Model::setBodyMass(const unsigned int id, const double mass)
 {
   if(IsFixedBodyId(id))
   {
-    mFixedBodies[id - fixed_body_discriminator].mMass = mass;
+    // The inertial parameters of the fixed body have already been merged in the parent body,
+    // in order to update correctly the parent body we need to first
+    // remove the inertial effects of the fixed body from his parent body
+    // Then update the fixed body inertia
+    // Finally, merge it again in the parent body
+    FixedBody& fixedbody(mFixedBodies[id - fixed_body_discriminator]);
+    mBodies[fixedbody.mMovableParent].Separate(fixedbody.mParentTransform, fixedbody.toBody());
+    fixedbody.mMass = mass;
+    mBodies[fixedbody.mMovableParent].Join(fixedbody.mParentTransform, fixedbody.toBody());
   }
   else
   {
@@ -543,7 +551,15 @@ void Model::setBodyInertia(const unsigned int id, const Math::Matrix3d &inertia)
 {
   if(IsFixedBodyId(id))
   {
-    mFixedBodies[id - fixed_body_discriminator].mInertia = inertia;
+    // The inertial parameters of the fixed body have already been merged in the parent body,
+    // in order to update correctly the parent body we need to first
+    // remove the inertial effects of the fixed body from his parent body
+    // Then update the fixed body inertia
+    // Finally, merge it again in the parent body
+    FixedBody& fixedbody(mFixedBodies[id - fixed_body_discriminator]);
+    mBodies[fixedbody.mMovableParent].Separate(fixedbody.mParentTransform, fixedbody.toBody());
+    fixedbody.mInertia = inertia;
+    mBodies[fixedbody.mMovableParent].Join(fixedbody.mParentTransform, fixedbody.toBody());
   }
   else
   {
@@ -557,7 +573,15 @@ void Model::setBodyCenterOfMass(const unsigned int id, const Math::Vector3d &com
 {
   if(IsFixedBodyId(id))
   {
-    mFixedBodies[id - fixed_body_discriminator].mCenterOfMass = com;
+    // The inertial parameters of the fixed body have already been merged in the parent body,
+    // in order to update correctly the parent body we need to first
+    // remove the inertial effects of the fixed body from his parent body
+    // Then update the fixed body inertia
+    // Finally, merge it again in the parent body
+    FixedBody& fixedbody(mFixedBodies[id - fixed_body_discriminator]);
+    mBodies[fixedbody.mMovableParent].Separate(fixedbody.mParentTransform, fixedbody.toBody());
+    fixedbody.mCenterOfMass = com;
+    mBodies[fixedbody.mMovableParent].Join(fixedbody.mParentTransform, fixedbody.toBody());
   }
   else
   {
@@ -572,9 +596,17 @@ void Model::setBodyInertialParameters(const unsigned int id, const double mass,
 {
   if(IsFixedBodyId(id))
   {
-    mFixedBodies[id - fixed_body_discriminator].mMass = mass;
-    mFixedBodies[id - fixed_body_discriminator].mInertia = inertia;
-    mFixedBodies[id - fixed_body_discriminator].mCenterOfMass = com;
+    // The inertial parameters of the fixed body have already been merged in the parent body,
+    // in order to update correctly the parent body we need to first
+    // remove the inertial effects of the fixed body from his parent body
+    // Then update the fixed body inertia
+    // Finally, merge it again in the parent body
+    FixedBody& fixedbody(mFixedBodies[id - fixed_body_discriminator]);
+    mBodies[fixedbody.mMovableParent].Separate(fixedbody.mParentTransform, fixedbody.toBody());
+    fixedbody.mMass = mass;
+    fixedbody.mInertia = inertia;
+    fixedbody.mCenterOfMass = com;
+    mBodies[fixedbody.mMovableParent].Join(fixedbody.mParentTransform, fixedbody.toBody());
   }
   else
   {

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -508,3 +508,19 @@ unsigned int Model::AddBodyCustomJoint (
   return body_id;
 }
 
+void Model::updateInertiaMatrixForBody(const unsigned int id)
+{
+  unsigned int body_id(id);
+  if(IsFixedBodyId(id))
+  {
+    body_id = mFixedBodies[id - fixed_body_discriminator].mMovableParent;
+  }
+
+  const Body &body(mBodies[body_id]);
+  Math::SpatialRigidBodyInertia rbi =
+      Math::SpatialRigidBodyInertia::createFromMassComInertiaC(
+          body.mMass, body.mCenterOfMass, body.mInertia);
+  Ic[id] = rbi;
+  I[id] = rbi;
+}
+

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -524,3 +524,64 @@ void Model::updateInertiaMatrixForBody(const unsigned int id)
   I[id] = rbi;
 }
 
+
+void Model::setBodyMass(const unsigned int id, const double mass)
+{
+  if(IsFixedBodyId(id))
+  {
+    mFixedBodies[id - fixed_body_discriminator].mMass = mass;
+  }
+  else
+  {
+    mBodies[id].mMass = mass;
+  }
+  updateInertiaMatrixForBody(id);
+}
+
+
+void Model::setBodyInertia(const unsigned int id, const Math::Matrix3d &inertia)
+{
+  if(IsFixedBodyId(id))
+  {
+    mFixedBodies[id - fixed_body_discriminator].mInertia = inertia;
+  }
+  else
+  {
+    mBodies[id].mInertia = inertia;
+  }
+  updateInertiaMatrixForBody(id);
+}
+
+
+void Model::setBodyCenterOfMass(const unsigned int id, const Math::Vector3d &com)
+{
+  if(IsFixedBodyId(id))
+  {
+    mFixedBodies[id - fixed_body_discriminator].mCenterOfMass = com;
+  }
+  else
+  {
+    mBodies[id].mCenterOfMass = com;
+  }
+  updateInertiaMatrixForBody(id);
+}
+
+
+void Model::setBodyInertialParameters(const unsigned int id, const double mass,
+                               const Math::Matrix3d &inertia, const Math::Vector3d &com)
+{
+  if(IsFixedBodyId(id))
+  {
+    mFixedBodies[id - fixed_body_discriminator].mMass = mass;
+    mFixedBodies[id - fixed_body_discriminator].mInertia = inertia;
+    mFixedBodies[id - fixed_body_discriminator].mCenterOfMass = com;
+  }
+  else
+  {
+    mBodies[id].mMass = mass;
+    mBodies[id].mInertia = inertia;
+    mBodies[id].mCenterOfMass = com;
+  }
+  updateInertiaMatrixForBody(id);
+}
+

--- a/tests/BodyTests.cc
+++ b/tests/BodyTests.cc
@@ -260,3 +260,122 @@ TEST_CASE (__FILE__"_TestBodyConstructorCopySpatialRigidBodyInertia", "" ) {
   CHECK_THAT (rbi.toMatrix(),
               AllCloseMatrix(rbi_from_matrix.toMatrix(), TEST_PREC, TEST_PREC));
 }
+
+TEST_CASE (__FILE__"_TestBodySeparateBody", "" ) {
+  Body body_init(1.1, Vector3d (1.5, 1.2, 1.3), Vector3d (1.4, 2., 3.));
+  const double mass_init = body_init.mMass;
+  const Math::Matrix3d inertia_init = body_init.mInertia;
+  const Math::Vector3d com_init = body_init.mCenterOfMass;
+
+  Body fixedbody_1(0.7, Vector3d (1.1, 0.8, 1.6), Vector3d (1.5, 1.2, 1.3));
+  Body fixedbody_2(0.4, Vector3d (0.7, 1.2, 0.9), Vector3d (0.6,0.7,0.2));
+  Math::SpatialTransform body1_transform(Matrix3d::Identity(), Vector3d::Zero());
+  Math::SpatialTransform body2_transform(Matrix3d::Identity(), Vector3d::Zero());
+
+  body_init.Join(body1_transform, fixedbody_1);
+
+  CHECK(fabs(body_init.mMass - (mass_init + fixedbody_1.mMass) < TEST_PREC));
+
+  const double mass_joined_1 = body_init.mMass;
+  const Math::Matrix3d inertia_joined_1 = body_init.mInertia;
+  const Math::Vector3d com_joined_1 = body_init.mCenterOfMass;
+  body_init.Join(body2_transform, fixedbody_2);
+
+  CHECK(fabs(body_init.mMass - (mass_init + fixedbody_1.mMass + fixedbody_2.mMass) < TEST_PREC));
+
+  body_init.Separate(body2_transform, fixedbody_2);
+
+  CHECK(fabs(body_init.mMass - (mass_init + fixedbody_1.mMass) < TEST_PREC));
+  CHECK_THAT(body_init.mInertia, AllCloseMatrix(inertia_joined_1, TEST_PREC, TEST_PREC));
+  CHECK_THAT(body_init.mCenterOfMass, AllCloseVector(com_joined_1, TEST_PREC, TEST_PREC));
+
+
+  body_init.Separate(body1_transform, fixedbody_1);
+
+  CHECK(fabs(body_init.mMass - (mass_init) < TEST_PREC));
+  CHECK_THAT(body_init.mInertia, AllCloseMatrix(inertia_init, TEST_PREC, TEST_PREC));
+  CHECK_THAT(body_init.mCenterOfMass, AllCloseVector(com_init, TEST_PREC, TEST_PREC));
+
+}
+
+
+TEST_CASE (__FILE__"_TestBodySeparateBodyWithTransform", "" ) {
+  Body body_init(1.1, Vector3d (1.5, 1.2, 1.3), Vector3d (1.4, 2., 3.));
+  const double mass_init = body_init.mMass;
+  const Math::Matrix3d inertia_init = body_init.mInertia;
+  const Math::Vector3d com_init = body_init.mCenterOfMass;
+
+  Body fixedbody_1(0.7, Vector3d (1.1, 0.8, 1.6), Vector3d (1.5, 1.2, 1.3));
+  Body fixedbody_2(0.4, Vector3d (0.7, 1.2, 0.9), Vector3d (0.6,0.7,0.2));
+  Math::SpatialTransform body1_transform(
+      (Xrotx(M_PI * 0.5) * Xroty(-M_PI * 0.7) * Xrotz(M_PI * 0.1)).E, Vector3d(1.1, 0.6, -0.8));
+  Math::SpatialTransform body2_transform(
+        (Xrotx(-M_PI * 0.6) * Xroty(-M_PI * 0.2) * Xrotz(M_PI * 0.9)).E, Vector3d(-0.3, 0.1, 1.8));
+
+  body_init.Join(body1_transform, fixedbody_1);
+
+  CHECK(fabs(body_init.mMass - (mass_init + fixedbody_1.mMass) < TEST_PREC));
+
+  const double mass_joined_1 = body_init.mMass;
+  const Math::Matrix3d inertia_joined_1 = body_init.mInertia;
+  const Math::Vector3d com_joined_1 = body_init.mCenterOfMass;
+  body_init.Join(body2_transform, fixedbody_2);
+
+  CHECK(fabs(body_init.mMass - (mass_init + fixedbody_1.mMass + fixedbody_2.mMass) < TEST_PREC));
+
+  body_init.Separate(body2_transform, fixedbody_2);
+
+  CHECK(fabs(body_init.mMass - (mass_init + fixedbody_1.mMass) < TEST_PREC));
+  CHECK_THAT(body_init.mInertia, AllCloseMatrix(inertia_joined_1, TEST_PREC, TEST_PREC));
+  CHECK_THAT(body_init.mCenterOfMass, AllCloseVector(com_joined_1, TEST_PREC, TEST_PREC));
+
+
+  body_init.Separate(body1_transform, fixedbody_1);
+
+  CHECK(fabs(body_init.mMass - (mass_init) < TEST_PREC));
+  CHECK_THAT(body_init.mInertia, AllCloseMatrix(inertia_init, TEST_PREC, TEST_PREC));
+  CHECK_THAT(body_init.mCenterOfMass, AllCloseVector(com_init, TEST_PREC, TEST_PREC));
+
+}
+
+TEST_CASE (__FILE__"_TestBodySeparateBodyWithTransformChangeOrder", "" ) {
+  Body body_init(1.1, Vector3d (1.5, 1.2, 1.3), Vector3d (1.4, 2., 3.));
+  const double mass_init = body_init.mMass;
+  const Math::Matrix3d inertia_init = body_init.mInertia;
+  const Math::Vector3d com_init = body_init.mCenterOfMass;
+
+  Body fixedbody_1(0.7, Vector3d (1.1, 0.8, 1.6), Vector3d (1.5, 1.2, 1.3));
+  Body fixedbody_2(0.4, Vector3d (0.7, 1.2, 0.9), Vector3d (0.6,0.7,0.2));
+  Math::SpatialTransform body1_transform(
+      (Xrotx(M_PI * 0.5) * Xroty(-M_PI * 0.7) * Xrotz(M_PI * 0.1)).E, Vector3d(1.1, 0.6, -0.8));
+  Math::SpatialTransform body2_transform(
+        (Xrotx(-M_PI * 0.6) * Xroty(-M_PI * 0.2) * Xrotz(M_PI * 0.9)).E, Vector3d(-0.3, 0.1, 1.8));
+
+  // create a body with only body_init and fixedbody_2 to check the values after joining and separating fixedbody_1
+  Body body_init_2(body_init);
+  body_init_2.Join(body2_transform, fixedbody_2);
+  CHECK(fabs(body_init_2.mMass - (mass_init + fixedbody_2.mMass) < TEST_PREC));
+
+
+  // Join fixedbody 1 and 2 in body init
+  body_init.Join(body1_transform, fixedbody_1);
+
+  CHECK(fabs(body_init.mMass - (mass_init + fixedbody_1.mMass) < TEST_PREC));
+
+  body_init.Join(body2_transform, fixedbody_2);
+
+  CHECK(fabs(body_init.mMass - (mass_init + fixedbody_1.mMass + fixedbody_2.mMass) < TEST_PREC));
+
+  body_init.Separate(body1_transform, fixedbody_1);
+
+  CHECK(fabs(body_init.mMass - (mass_init + fixedbody_2.mMass) < TEST_PREC));
+  CHECK_THAT(body_init.mInertia, AllCloseMatrix(body_init_2.mInertia, TEST_PREC, TEST_PREC));
+  CHECK_THAT(body_init.mCenterOfMass, AllCloseVector(body_init_2.mCenterOfMass, TEST_PREC, TEST_PREC));
+
+
+  body_init.Separate(body2_transform, fixedbody_2);
+
+  CHECK(fabs(body_init.mMass - (mass_init) < TEST_PREC));
+  CHECK_THAT(body_init.mInertia, AllCloseMatrix(inertia_init, TEST_PREC, TEST_PREC));
+  CHECK_THAT(body_init.mCenterOfMass, AllCloseVector(com_init, TEST_PREC, TEST_PREC));
+}

--- a/tests/ModelTests.cc
+++ b/tests/ModelTests.cc
@@ -743,38 +743,38 @@ TEST_CASE (__FILE__"_TestUpdateBodyInertiaParameters", "") {
   // check that inertia parameters for the first three bodies are all at 0
   for(unsigned int i = 0 ; i < 3 ; ++i)
   {
-    CHECK(0 == model.Ic[i].m);
-    CHECK(0 == model.Ic[i].Ixx);
-    CHECK(0 == model.Ic[i].Iyx);
-    CHECK(0 == model.Ic[i].Iyy);
-    CHECK(0 == model.Ic[i].Izx);
-    CHECK(0 == model.Ic[i].Izy);
-    CHECK(0 == model.Ic[i].Izz);
+    CHECK(0 == model.I[i].m);
+    CHECK(0 == model.I[i].Ixx);
+    CHECK(0 == model.I[i].Iyx);
+    CHECK(0 == model.I[i].Iyy);
+    CHECK(0 == model.I[i].Izx);
+    CHECK(0 == model.I[i].Izy);
+    CHECK(0 == model.I[i].Izz);
     CHECK_THAT(Vector3d::Zero(), AllCloseVector(model.Ic[0].h));
   }
 
-  CHECK(fabs(1. - model.Ic[3].m) < TEST_PREC);
-  CHECK(fabs(3. - model.Ic[3].Ixx) < TEST_PREC);
-  CHECK(fabs(-1. - model.Ic[3].Iyx) < TEST_PREC);
-  CHECK(fabs(3. - model.Ic[3].Iyy) < TEST_PREC);
-  CHECK(fabs(-1. - model.Ic[3].Izx) < TEST_PREC);
-  CHECK(fabs(-1. - model.Ic[3].Izy) < TEST_PREC);
-  CHECK(fabs(3. - model.Ic[3].Izz) < TEST_PREC);
+  CHECK(fabs(1. - model.I[3].m) < TEST_PREC);
+  CHECK(fabs(3. - model.I[3].Ixx) < TEST_PREC);
+  CHECK(fabs(-1. - model.I[3].Iyx) < TEST_PREC);
+  CHECK(fabs(3. - model.I[3].Iyy) < TEST_PREC);
+  CHECK(fabs(-1. - model.I[3].Izx) < TEST_PREC);
+  CHECK(fabs(-1. - model.I[3].Izy) < TEST_PREC);
+  CHECK(fabs(3. - model.I[3].Izz) < TEST_PREC);
   CHECK_THAT(Vector3d (1., 1., 1.), AllCloseVector(model.Ic[3].h));
 
-  CHECK(fabs(0.4 - model.Ic[4].m) < TEST_PREC);
-  CHECK(fabs(1.5 - model.Ic[4].Ixx) < TEST_PREC);
-  CHECK(fabs(-0.336 - model.Ic[4].Iyx) < TEST_PREC);
-  CHECK(fabs(1.22 - model.Ic[4].Iyy) < TEST_PREC);
-  CHECK(fabs(-0.252 - model.Ic[4].Izx) < TEST_PREC);
-  CHECK(fabs(-0.432 - model.Ic[4].Izy) < TEST_PREC);
-  CHECK(fabs(0.972 - model.Ic[4].Izz) < TEST_PREC);
+  CHECK(fabs(0.4 - model.I[4].m) < TEST_PREC);
+  CHECK(fabs(1.5 - model.I[4].Ixx) < TEST_PREC);
+  CHECK(fabs(-0.336 - model.I[4].Iyx) < TEST_PREC);
+  CHECK(fabs(1.22 - model.I[4].Iyy) < TEST_PREC);
+  CHECK(fabs(-0.252 - model.I[4].Izx) < TEST_PREC);
+  CHECK(fabs(-0.432 - model.I[4].Izy) < TEST_PREC);
+  CHECK(fabs(0.972 - model.I[4].Izz) < TEST_PREC);
   CHECK_THAT(Vector3d (0.7, 1.2, 0.9) * 0.4, AllCloseVector(model.Ic[4].h));
 
   // update inertia parameters of body 2 and check if the Ic matrix is correctly updated
   model.setBodyMass(id_body_2, 1.6);
   CHECK(fabs(1.6 - model.mBodies[id_body_2].mMass) < TEST_PREC);
-  CHECK(fabs(1.6 - model.Ic[id_body_2].m) < TEST_PREC);
+  CHECK(fabs(1.6 - model.I[id_body_2].m) < TEST_PREC);
   CHECK_THAT(Vector3d (0.7, 1.2, 0.9) * 1.6, AllCloseVector(model.Ic[id_body_2].h));
 
   model.setBodyCenterOfMass(id_body_2, Vector3d(1.2, 0.6, -0.7));
@@ -786,22 +786,127 @@ TEST_CASE (__FILE__"_TestUpdateBodyInertiaParameters", "") {
   Math::SpatialRigidBodyInertia rbi =
       Math::SpatialRigidBodyInertia::createFromMassComInertiaC(
           model.mBodies[id_body_2].mMass, model.mBodies[id_body_2].mCenterOfMass, model.mBodies[id_body_2].mInertia);
-  CHECK(fabs(rbi.Ixx - model.Ic[id_body_2].Ixx) < TEST_PREC);
-  CHECK(fabs(rbi.Iyx - model.Ic[id_body_2].Iyx) < TEST_PREC);
-  CHECK(fabs(rbi.Iyy - model.Ic[id_body_2].Iyy) < TEST_PREC);
-  CHECK(fabs(rbi.Izx - model.Ic[id_body_2].Izx) < TEST_PREC);
-  CHECK(fabs(rbi.Izy - model.Ic[id_body_2].Izy) < TEST_PREC);
-  CHECK(fabs(rbi.Izz - model.Ic[id_body_2].Izz) < TEST_PREC);
+  CHECK(fabs(rbi.Ixx - model.I[id_body_2].Ixx) < TEST_PREC);
+  CHECK(fabs(rbi.Iyx - model.I[id_body_2].Iyx) < TEST_PREC);
+  CHECK(fabs(rbi.Iyy - model.I[id_body_2].Iyy) < TEST_PREC);
+  CHECK(fabs(rbi.Izx - model.I[id_body_2].Izx) < TEST_PREC);
+  CHECK(fabs(rbi.Izy - model.I[id_body_2].Izy) < TEST_PREC);
+  CHECK(fabs(rbi.Izz - model.I[id_body_2].Izz) < TEST_PREC);
 
   model.setBodyInertialParameters(id_body_2, 0.4, inertia_body_2_init ,Vector3d(0.7, 1.2, 0.9));
-  CHECK(fabs(0.4 - model.Ic[id_body_2].m) < TEST_PREC);
-  CHECK(fabs(1.5 - model.Ic[id_body_2].Ixx) < TEST_PREC);
-  CHECK(fabs(-0.336 - model.Ic[id_body_2].Iyx) < TEST_PREC);
-  CHECK(fabs(1.22 - model.Ic[id_body_2].Iyy) < TEST_PREC);
-  CHECK(fabs(-0.252 - model.Ic[id_body_2].Izx) < TEST_PREC);
-  CHECK(fabs(-0.432 - model.Ic[id_body_2].Izy) < TEST_PREC);
-  CHECK(fabs(0.972 - model.Ic[id_body_2].Izz) < TEST_PREC);
+  CHECK(fabs(0.4 - model.I[id_body_2].m) < TEST_PREC);
+  CHECK(fabs(1.5 - model.I[id_body_2].Ixx) < TEST_PREC);
+  CHECK(fabs(-0.336 - model.I[id_body_2].Iyx) < TEST_PREC);
+  CHECK(fabs(1.22 - model.I[id_body_2].Iyy) < TEST_PREC);
+  CHECK(fabs(-0.252 - model.I[id_body_2].Izx) < TEST_PREC);
+  CHECK(fabs(-0.432 - model.I[id_body_2].Izy) < TEST_PREC);
+  CHECK(fabs(0.972 - model.I[id_body_2].Izz) < TEST_PREC);
   CHECK_THAT(Vector3d (0.7, 1.2, 0.9) * 0.4, AllCloseVector(model.Ic[4].h));
 
 }
 
+
+TEST_CASE (__FILE__"_TestUpdateFixedBodyInertiaParameters", "") {
+  // create a model with a floating base and 2 revolute joints
+  Model model;
+  Body body_root;
+  Joint float_base_joint (JointTypeFloatingBase);
+  model.AppendBody (SpatialTransform(), float_base_joint, body_root);
+
+  // floating base joint type add 3 bodies
+  CHECK (3 == model.mBodies.size());
+
+  Body body1 (1., Vector3d (1., 1., 1.), Vector3d (1., 1., 1.));
+  const unsigned int id_body_1 = model.AppendBody (Xrotx (45 * M_PI / 180), JointTypeRevoluteX, body1, "body1");
+  Body body2(0.4, Vector3d (0.7, 1.2, 0.9), Vector3d (0.6,0.7,0.2));
+  const Matrix3d inertia_body_2_init(body2.mInertia);
+  const unsigned int id_fixedbody_2 = model.AppendBody(
+      Xtrans(Vector3d(0., 1., 0.)), Joint(JointTypeFixed), body2, "fixedbody2");
+  Body body3(0.7, Vector3d (1.1, 0.8, 1.6), Vector3d (1.5, 1.2, 1.3));
+  const unsigned int id_fixedbody_3 = model.AppendBody(
+      Xtrans(Vector3d(0., 0., 0.5)), Joint(JointTypeFixed), body3, "fixedbody3");
+
+  CHECK (4 == model.mBodies.size());
+  CHECK (2 == model.mFixedBodies.size());
+  CHECK (4 == model.Ic.size());
+  CHECK (4 == model.I.size());
+
+  const Body& body1_merged(model.mBodies[id_body_1]);
+  const double init_total_mass = body1.mMass + body2.mMass + body3.mMass;
+  CHECK(fabs(init_total_mass - body1_merged.mMass) < TEST_PREC);
+  CHECK(fabs(init_total_mass - model.I[id_body_1].m) < TEST_PREC);
+  const Vector3d initial_com_body1_merged = body1_merged.mCenterOfMass;
+  const Matrix3d initial_inertia_body1_merged = body1_merged.mInertia;
+  const Math::SpatialRigidBodyInertia initial_rbi_body1_merged = model.I[id_body_1];
+  // update mass of fixed body 2 and check that:
+  // 1) the fixed body mass is updated
+  // 2) the mass of the merged body 1 is updated
+  // 3) the Inertia matrix at id_body_1 is updated
+
+  model.setBodyMass(id_fixedbody_2, 1.6);
+  double total_mass = body1.mMass + 1.6 + body3.mMass;
+  CHECK(fabs(1.6 - model.mFixedBodies[id_fixedbody_2 - model.fixed_body_discriminator].mMass) <
+        TEST_PREC);
+  CHECK(fabs(total_mass - model.mBodies[id_body_1].mMass) < TEST_PREC);
+  CHECK(fabs(total_mass - model.I[id_body_1].m) < TEST_PREC);
+
+  Vector3d com_body1_merged = model.mBodies[id_body_1].mCenterOfMass;
+  Matrix3d inertia_body1_merged = model.mBodies[id_body_1].mInertia;
+
+
+  model.setBodyCenterOfMass(id_fixedbody_2, Vector3d(1., 1., 1.));
+  CHECK_THAT(Vector3d(1., 1., 1.),
+             AllCloseVector(
+                 model.mFixedBodies[id_fixedbody_2 - model.fixed_body_discriminator].mCenterOfMass));
+  CHECK_FALSE(com_body1_merged.isApprox(model.mBodies[id_body_1].mCenterOfMass));
+
+  Math::SpatialRigidBodyInertia rbi = Math::SpatialRigidBodyInertia::createFromMassComInertiaC(
+      model.mBodies[id_body_1].mMass, model.mBodies[id_body_1].mCenterOfMass,
+      model.mBodies[id_body_1].mInertia);
+  CHECK(fabs(rbi.Ixx - model.I[id_body_1].Ixx) < TEST_PREC);
+  CHECK(fabs(rbi.Iyx - model.I[id_body_1].Iyx) < TEST_PREC);
+  CHECK(fabs(rbi.Iyy - model.I[id_body_1].Iyy) < TEST_PREC);
+  CHECK(fabs(rbi.Izx - model.I[id_body_1].Izx) < TEST_PREC);
+  CHECK(fabs(rbi.Izy - model.I[id_body_1].Izy) < TEST_PREC);
+  CHECK(fabs(rbi.Izz - model.I[id_body_1].Izz) < TEST_PREC);
+  CHECK_THAT(rbi.h, AllCloseVector(model.I[id_body_1].h));
+
+  model.setBodyInertia(id_fixedbody_2, Matrix3d::Identity());
+  CHECK_THAT(Matrix3d::Identity(),
+             AllCloseMatrix(
+                 model.mFixedBodies[id_fixedbody_2 - model.fixed_body_discriminator].mInertia));
+  CHECK_FALSE(inertia_body1_merged.isApprox(model.mBodies[id_body_1].mInertia));
+
+  rbi = Math::SpatialRigidBodyInertia::createFromMassComInertiaC(
+      model.mBodies[id_body_1].mMass, model.mBodies[id_body_1].mCenterOfMass,
+      model.mBodies[id_body_1].mInertia);
+  CHECK(fabs(rbi.Ixx - model.I[id_body_1].Ixx) < TEST_PREC);
+  CHECK(fabs(rbi.Iyx - model.I[id_body_1].Iyx) < TEST_PREC);
+  CHECK(fabs(rbi.Iyy - model.I[id_body_1].Iyy) < TEST_PREC);
+  CHECK(fabs(rbi.Izx - model.I[id_body_1].Izx) < TEST_PREC);
+  CHECK(fabs(rbi.Izy - model.I[id_body_1].Izy) < TEST_PREC);
+  CHECK(fabs(rbi.Izz - model.I[id_body_1].Izz) < TEST_PREC);
+
+
+  // put back initial values:
+  model.setBodyInertialParameters(id_fixedbody_2, 0.4, inertia_body_2_init ,Vector3d(0.7, 1.2, 0.9));
+  CHECK(fabs(0.4 - model.mFixedBodies[id_fixedbody_2 - model.fixed_body_discriminator].mMass) < TEST_PREC);
+  CHECK_THAT(Vector3d(0.7, 1.2, 0.9),
+             AllCloseVector(
+                 model.mFixedBodies[id_fixedbody_2 - model.fixed_body_discriminator].mCenterOfMass));
+  CHECK_THAT(inertia_body_2_init,
+             AllCloseMatrix(
+                 model.mFixedBodies[id_fixedbody_2 - model.fixed_body_discriminator].mInertia));
+  CHECK(fabs(init_total_mass - model.I[id_body_1].m) < TEST_PREC);
+  CHECK(fabs(init_total_mass - model.mBodies[id_body_1].mMass) < TEST_PREC);
+  CHECK_THAT(initial_com_body1_merged, AllCloseVector(model.mBodies[id_body_1].mCenterOfMass));
+  CHECK_THAT(initial_inertia_body1_merged, AllCloseMatrix(model.mBodies[id_body_1].mInertia));
+
+  CHECK_THAT(initial_rbi_body1_merged.h, AllCloseVector(model.I[id_body_1].h));
+  CHECK(fabs(initial_rbi_body1_merged.Ixx - model.I[id_body_1].Ixx) < TEST_PREC);
+  CHECK(fabs(initial_rbi_body1_merged.Iyx - model.I[id_body_1].Iyx) < TEST_PREC);
+  CHECK(fabs(initial_rbi_body1_merged.Iyy - model.I[id_body_1].Iyy) < TEST_PREC);
+  CHECK(fabs(initial_rbi_body1_merged.Izx - model.I[id_body_1].Izx) < TEST_PREC);
+  CHECK(fabs(initial_rbi_body1_merged.Izy - model.I[id_body_1].Izy) < TEST_PREC);
+  CHECK(fabs(initial_rbi_body1_merged.Izz - model.I[id_body_1].Izz) < TEST_PREC);
+}


### PR DESCRIPTION
See (https://github.com/rbdl/rbdl/issues/86)

This PR add the necessary API to update body inertial parameters (mass, inertia or CoM position) after creating the model. This work also for fixed body and correctly update the model.I matrix. 

In order to do this, the new methods in Model must be used.
```
  void Model::setBodyMass(const unsigned int id, const double mass)

  void Model::setBodyInertia(const unsigned int id, const Math::Matrix3d &inertia)

  void Model::setBodyCenterOfMass(const unsigned int id, const Math::Vector3d &com)

  void Model::setBodyInertialParameters(const unsigned int id, const double mass,
                                 const Math::Matrix3d &inertia, const Math::Vector3d &com)
```

I didn't change the existing API so it is still possible for the user to edit a body via `model.mBodies[id].mMass = xxx` for example, but doing so will lead to inconsistent data in the model because the I matrix is never updated. Also, this doesn't work in the case of fixed body. (This is the same behaviour as before this PR). 


Related tests cases have been added for the new methods.
