### PR TITLE
Fix the partial model loading when using multiple tip links

### DIFF
--- a/addons/urdfreader/urdfreader.cc
+++ b/addons/urdfreader/urdfreader.cc
@@ -449,6 +449,12 @@ void construct_partial_model(Model *rbdl_model, ModelPtr urdf_model,
         vector<string> local_joint_names;
         string parent_link = tip_link;
         vector<string> links_verbose;
+        if (link_map.count(tip_link) == 0) {
+          ostringstream error_msg;
+          error_msg << "Error while processing tip link '" << tip_link
+                    << "': tip link could not be found in the model." << endl;
+          throw RBDLFileParseError(error_msg.str());
+        }
         while(parent_link.compare(root_link) != 0)
         {
           ostringstream verbose_string;
@@ -466,7 +472,7 @@ void construct_partial_model(Model *rbdl_model, ModelPtr urdf_model,
               link_map[parent_link]->parent_joint->name);
           }
           parent_link = link_map[parent_link]->getParent()->name;
-          if (verbose) {
+          if (verbose && link_map[parent_link]->parent_joint) {
             verbose_string
                 << "joint '" << link_map[parent_link]->parent_joint->name
                 << "' child link '"


### PR DESCRIPTION
Hello!

During our testing, we found that the loading of a partial model failed at one instance with a segmentation fault and at another end when a duplicated body is added, it complains. For this reason, I've added a small fix and a test, and now the test is passing and this avoids any further segmentation faults