### PR TITLE
Adapted find package Eigen3 to modern CMake

### DIFF
--- a/CMake/FindCasadi.cmake
+++ b/CMake/FindCasadi.cmake
@@ -5,6 +5,8 @@
 #  Casadi_LIBRARIES   - List of libraries when using Casadi.
 #  Casadi_FOUND       - True if Casadi is found.
 
+set(Casadi_DIR "" CACHE PATH "Path to Casadi installation")
+
 if (Casadi_INCLUDE_DIR)
   # Already in cache, be silent
   set (Casadi_FIND_QUIETLY TRUE)
@@ -12,13 +14,20 @@ endif (Casadi_INCLUDE_DIR)
 
 find_path (Casadi_INCLUDE_DIR "casadi.hpp" 
     PATHS
+    ${Casadi_DIR}/casadi
+    ${Casadi_DIR}/include/casadi
     ${CMAKE_INSTALL_PREFIX}/include/casadi
     ${CMAKE_INSTALL_PREFIX}/Library/include/casadi
     /usr/local/include/casadi
     /usr/include/casadi
 )
 find_library (Casadi_LIBRARY NAMES casadi 
-    PATHS ${CMAKE_INSTALL_PREFIX}/lib ${CMAKE_INSTALL_PREFIX}/Library/lib
+    PATHS 
+    ${Casadi_DIR}
+    ${Casadi_DIR}/lib
+    ${Casadi_DIR}/Library/lib
+    ${CMAKE_INSTALL_PREFIX}/lib 
+    ${CMAKE_INSTALL_PREFIX}/Library/lib
     /usr/lib
 )
 
@@ -29,6 +38,3 @@ find_package_handle_standard_args (Casadi DEFAULT_MSG
     Casadi_LIBRARY
     Casadi_INCLUDE_DIR
 )
-
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,10 @@ IF (NOT EIGEN3_FOUND)
     MESSAGE (WARNING "Could not find Eigen3 on your system. Please install it!")
 ENDIF (NOT EIGEN3_FOUND)
 
+if(NOT DEFINED EIGEN3_INCLUDE_DIR OR EIGEN3_INCLUDE_DIR STREQUAL "")
+    # Modern CMake does not set INCLUDE_DIR, so make it retro-compatible
+    get_target_property(EIGEN3_INCLUDE_DIR Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+endif()
 INCLUDE_DIRECTORIES (${EIGEN3_INCLUDE_DIR})
 
 # Addons


### PR DESCRIPTION
This is a small fix that the modern cmake way to install Eigen so it fits the way RBDL uses it 