### PR TITLE
Support Eigen 5 includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,16 @@ OPTION (RBDL_BUILD_CASADI "Use the CasADi backend" OFF)
 OPTION (RBDL_VCPKG_BUILD "Building RBDL in vcpkg environment" OFF)
 
 
-# Find and use the system's Eigen3 library
-FIND_PACKAGE (Eigen3 3.0.0)
+# Find and use the system's Eigen library.
+SET (RBDL_EIGEN_MIN_VERSION 3.0.0 CACHE STRING "Minimum Eigen version required by RBDL")
+FIND_PACKAGE (Eigen3 ${RBDL_EIGEN_MIN_VERSION} QUIET)
+
+IF (TARGET Eigen3::Eigen)
+  GET_TARGET_PROPERTY (EIGEN3_INCLUDE_DIR Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+  SET (EIGEN3_FOUND TRUE)
+ELSEIF (EIGEN3_INCLUDE_DIR AND EXISTS "${EIGEN3_INCLUDE_DIR}/Eigen/Core")
+  SET (EIGEN3_FOUND TRUE)
+ENDIF()
 
 IF (NOT EIGEN3_FOUND)
     MESSAGE (WARNING "Could not find Eigen3 on your system. Please install it!")

--- a/include/rbdl/rbdl_eigenmath.h
+++ b/include/rbdl/rbdl_eigenmath.h
@@ -44,15 +44,11 @@ class RBDL_TEMPLATE_DLLAPI Vector2_t : public Eigen::Vector2d
         const double& v0, const double& v1
         )
     {
-      Base::_check_template_params();
-
       (*this) << v0, v1;
     }
 
     void set(const double& v0, const double& v1)
     {
-      Base::_check_template_params();
-
       (*this) << v0, v1;
     }
 };
@@ -81,15 +77,11 @@ class RBDL_TEMPLATE_DLLAPI Vector3_t : public Eigen::Vector3d
         const double& v0, const double& v1, const double& v2
         )
     {
-      Base::_check_template_params();
-
       (*this) << v0, v1, v2;
     }
 
     void set(const double& v0, const double& v1, const double& v2)
     {
-      Base::_check_template_params();
-
       (*this) << v0, v1, v2;
     }
 };
@@ -120,8 +112,6 @@ class RBDL_TEMPLATE_DLLAPI Matrix3_t : public Eigen::Matrix3d
         const double& m20, const double& m21, const double& m22
         )
     {
-      Base::_check_template_params();
-
       (*this)
         << m00, m01, m02,
         m10, m11, m12,
@@ -154,15 +144,11 @@ class RBDL_TEMPLATE_DLLAPI Vector4_t : public Eigen::Vector4d
         const double& v0, const double& v1, const double& v2, const double& v3
         )
     {
-      Base::_check_template_params();
-
       (*this) << v0, v1, v2, v3;
     }
 
     void set(const double& v0, const double& v1, const double& v2, const double& v3)
     {
-      Base::_check_template_params();
-
       (*this) << v0, v1, v2, v3;
     }
 };
@@ -192,8 +178,6 @@ class RBDL_TEMPLATE_DLLAPI SpatialVector_t : public Eigen::Matrix<double, 6, 1>
         const double& v3, const double& v4, const double& v5
         )
     {
-      Base::_check_template_params();
-
       (*this) << v0, v1, v2, v3, v4, v5;
     }
 
@@ -202,8 +186,6 @@ class RBDL_TEMPLATE_DLLAPI SpatialVector_t : public Eigen::Matrix<double, 6, 1>
         const double& v3, const double& v4, const double& v5
         )
     {
-      Base::_check_template_params();
-
       (*this) << v0, v1, v2, v3, v4, v5;
     }
 };
@@ -235,8 +217,6 @@ class RBDL_TEMPLATE_DLLAPI Matrix4_t : public Eigen::Matrix<double, 4, 4>
         const Scalar& m30, const Scalar& m31, const Scalar& m32, const Scalar& m33
         )
     {
-      Base::_check_template_params();
-
       (*this)
         << m00, m01, m02, m03
         , m10, m11, m12, m13
@@ -252,8 +232,6 @@ class RBDL_TEMPLATE_DLLAPI Matrix4_t : public Eigen::Matrix<double, 4, 4>
         const Scalar& m30, const Scalar& m31, const Scalar& m32, const Scalar& m33
         )
     {
-      Base::_check_template_params();
-
       (*this)
         << m00, m01, m02, m03
         , m10, m11, m12, m13
@@ -292,8 +270,6 @@ class RBDL_TEMPLATE_DLLAPI SpatialMatrix_t : public Eigen::Matrix<double, 6, 6>
         const Scalar& m50, const Scalar& m51, const Scalar& m52, const Scalar& m53, const Scalar& m54, const Scalar& m55
         )
     {
-      Base::_check_template_params();
-
       (*this)
         << m00, m01, m02, m03, m04, m05
         , m10, m11, m12, m13, m14, m15
@@ -313,8 +289,6 @@ class RBDL_TEMPLATE_DLLAPI SpatialMatrix_t : public Eigen::Matrix<double, 6, 6>
         const Scalar& m50, const Scalar& m51, const Scalar& m52, const Scalar& m53, const Scalar& m54, const Scalar& m55
         )
     {
-      Base::_check_template_params();
-
       (*this)
         << m00, m01, m02, m03, m04, m05
         , m10, m11, m12, m13, m14, m15


### PR DESCRIPTION
## Summary
- Allow RBDL to consume Eigen through modern CMake config targets or an explicit EIGEN3_INCLUDE_DIR path.
- Remove calls to Eigen internal template-checking APIs from RBDL math wrapper constructors.

## Validation
- Configured and built the benchmark target locally with Eigen 5.0.0 headers on AppleClang 16 before this PR was simplified.
- The benchmark code and comparison script were intentionally removed from this PR to keep the Eigen 5 compatibility change focused.