### PR TITLE
Modernize optional dependency find modules

### DIFF
--- a/CMake/FindCasadi.cmake
+++ b/CMake/FindCasadi.cmake
@@ -10,7 +10,37 @@ if (Casadi_INCLUDE_DIR)
   set (Casadi_FIND_QUIETLY TRUE)
 endif (Casadi_INCLUDE_DIR)
 
-find_path (Casadi_INCLUDE_DIR "casadi.hpp" 
+find_package (Casadi CONFIG QUIET)
+if (NOT Casadi_FOUND)
+  find_package (casadi CONFIG QUIET)
+  if (casadi_FOUND)
+    set (Casadi_FOUND TRUE)
+  endif()
+endif()
+
+foreach (_casadi_target Casadi::casadi casadi::casadi casadi)
+  if (TARGET ${_casadi_target})
+    set (Casadi_LIBRARY ${_casadi_target})
+    if (NOT Casadi_INCLUDE_DIR)
+      get_target_property (Casadi_INCLUDE_DIR ${_casadi_target} INTERFACE_INCLUDE_DIRECTORIES)
+    endif()
+  endif()
+endforeach()
+
+if (NOT Casadi_INCLUDE_DIR AND Casadi_INCLUDE_DIRS)
+  list (GET Casadi_INCLUDE_DIRS 0 Casadi_INCLUDE_DIR)
+endif()
+if (NOT Casadi_INCLUDE_DIR AND casadi_INCLUDE_DIRS)
+  list (GET casadi_INCLUDE_DIRS 0 Casadi_INCLUDE_DIR)
+endif()
+if (NOT Casadi_LIBRARY AND Casadi_LIBRARIES)
+  list (GET Casadi_LIBRARIES 0 Casadi_LIBRARY)
+endif()
+if (NOT Casadi_LIBRARY AND casadi_LIBRARIES)
+  list (GET casadi_LIBRARIES 0 Casadi_LIBRARY)
+endif()
+
+find_path (Casadi_INCLUDE_DIR "casadi.hpp"
     PATHS
     ${CMAKE_INSTALL_PREFIX}/include/casadi
     ${CMAKE_INSTALL_PREFIX}/Library/include/casadi
@@ -29,6 +59,5 @@ find_package_handle_standard_args (Casadi DEFAULT_MSG
     Casadi_LIBRARY
     Casadi_INCLUDE_DIR
 )
-
 
 

--- a/CMake/FindIPOPT.cmake
+++ b/CMake/FindIPOPT.cmake
@@ -1,42 +1,57 @@
-SET (IPOPT_FOUND FALSE)
+find_package (Ipopt CONFIG QUIET)
 
+if (Ipopt_FOUND AND NOT IPOPT_FOUND)
+  foreach (_ipopt_target Ipopt::ipopt ipopt::ipopt ipopt)
+    if (TARGET ${_ipopt_target})
+      set (IPOPT_LIBRARY ${_ipopt_target})
+      if (NOT IPOPT_INCLUDE_DIR)
+        get_target_property (IPOPT_INCLUDE_DIR ${_ipopt_target} INTERFACE_INCLUDE_DIRECTORIES)
+      endif()
+    endif()
+  endforeach()
 
-UNSET( IPOPT_INCLUDE_DIR              CACHE)   
-UNSET( IPOPT_LIBRARY                  CACHE)    
+  if (NOT IPOPT_INCLUDE_DIR AND Ipopt_INCLUDE_DIRS)
+    list (GET Ipopt_INCLUDE_DIRS 0 IPOPT_INCLUDE_DIR)
+  endif()
+  if (NOT IPOPT_LIBRARY AND Ipopt_LIBRARIES)
+    list (GET Ipopt_LIBRARIES 0 IPOPT_LIBRARY)
+  endif()
+endif()
 
-FIND_PATH (IPOPT_INCLUDE_DIR IpTNLP.hpp
-  PATHS 
+find_package (PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules (IPOPT_PC QUIET ipopt)
+endif()
+
+find_path (IPOPT_INCLUDE_DIR IpTNLP.hpp
+  HINTS
+  ${IPOPT_PC_INCLUDE_DIRS}
+  PATHS
   ${CUSTOM_IPOPT_PATH}/include
   PATH_SUFFIXES
-	coin
-    coin-or
+  coin
+  coin-or
   )
 
-FIND_LIBRARY (IPOPT_LIBRARY ipopt
+find_library (IPOPT_LIBRARY ipopt
+  HINTS
+  ${IPOPT_PC_LIBRARY_DIRS}
   PATHS
   ${CUSTOM_IPOPT_PATH}/lib
   )
 
-IF (IPOPT_INCLUDE_DIR AND IPOPT_LIBRARY)
-  SET (IPOPT_FOUND TRUE)
-ELSE(IPOPT_INCLUDE_DIR AND IPOPT_LIBRARY)
-  IF(IPOPT_FIND_REQUIRED)
-    MESSAGE (SEND_ERROR " Could not find IPOPT.")
-    MESSAGE (SEND_ERROR " Try setting CUSTOM_IPOPT_PATH in FindIPOPT.cmake force CMake to use the desired directory.")
-  ELSE(IPOPT_FIND_REQUIRED)
-    MESSAGE (STATUS " Could not find IPOPT.")
-    MESSAGE (STATUS " Try setting CUSTOM_IPOPT_PATH in FindIPOPT.cmake force CMake to use the desired directory.")
-  ENDIF(IPOPT_FIND_REQUIRED)
-ENDIF (IPOPT_INCLUDE_DIR AND IPOPT_LIBRARY)
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (IPOPT DEFAULT_MSG
+  IPOPT_LIBRARY
+  IPOPT_INCLUDE_DIR
+  )
 
-IF (IPOPT_FOUND)
-   IF (NOT IPOPT_FIND_QUIETLY)
-      MESSAGE(STATUS "Found IPOPT: ${IPOPT_LIBRARY}")
-   ENDIF (NOT IPOPT_FIND_QUIETLY)
+if (IPOPT_FOUND)
+  set (IPOPT_LIBRARIES ${IPOPT_LIBRARY})
+  set (IPOPT_INCLUDE_DIRS ${IPOPT_INCLUDE_DIR})
+endif()
 
-ENDIF (IPOPT_FOUND)
-
-MARK_AS_ADVANCED (
+mark_as_advanced (
   IPOPT_INCLUDE_DIR
   IPOPT_LIBRARY
   )

--- a/addons/urdfreader/CMake/FindURDF.cmake
+++ b/addons/urdfreader/CMake/FindURDF.cmake
@@ -1,88 +1,93 @@
-# - Try to find URDF
+# - Try to find URDF dependencies
 #
-#
 
-SET (URDF_FOUND FALSE)
-SET (CONSOLE_BRIDGE_FOUND FALSE)
-SET (URDFDOM_HEADERS_FOUND FALSE)
-SET (URDFDOM_FOUND FALSE)
+find_package (PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules (CONSOLE_BRIDGE_PC QUIET console_bridge)
+  pkg_check_modules (URDFDOM_HEADERS_PC QUIET urdfdom_headers)
+  pkg_check_modules (URDFDOM_PC QUIET urdfdom)
+endif()
 
-FIND_PATH (CONSOLE_BRIDGE_DIR console_bridge/console.h
-	/usr/local/include
-	/usr/include
-	)
+find_path (CONSOLE_BRIDGE_DIR console_bridge/console.h
+  HINTS
+  ${CONSOLE_BRIDGE_PC_INCLUDE_DIRS}
+  PATHS
+  /usr/local/include
+  /usr/include
+  )
 
-FIND_LIBRARY (CONSOLE_BRIDGE_LIBRARY NAMES console_bridge PATHS
-	/usr/local/include
-	/usr/include
-	)
+find_library (CONSOLE_BRIDGE_LIBRARY NAMES console_bridge
+  HINTS
+  ${CONSOLE_BRIDGE_PC_LIBRARY_DIRS}
+  PATHS
+  /usr/local/lib
+  /usr/lib
+  )
 
-FIND_PATH (URDFDOM_HEADERS_DIR urdf_model/model.h
-	/usr/local/include
-	/usr/include
-	)
+find_path (URDFDOM_HEADERS_DIR urdf_model/model.h
+  HINTS
+  ${URDFDOM_HEADERS_PC_INCLUDE_DIRS}
+  ${URDFDOM_PC_INCLUDE_DIRS}
+  PATHS
+  /usr/local/include
+  /usr/include
+  )
 
-FIND_PATH (URDFDOM_DIR urdf_parser/urdf_parser.h
-	/usr/local/include
-	/usr/include
-	)
+find_path (URDFDOM_DIR urdf_parser/urdf_parser.h
+  HINTS
+  ${URDFDOM_PC_INCLUDE_DIRS}
+  PATHS
+  /usr/local/include
+  /usr/include
+  )
 
-FIND_LIBRARY (URDFDOM_MODEL_LIBRARY NAMES urdfdom_model PATHS
-	/usr/local/include
-	/usr/include
-	)
+find_library (URDFDOM_MODEL_LIBRARY NAMES urdfdom_model
+  HINTS
+  ${URDFDOM_PC_LIBRARY_DIRS}
+  PATHS
+  /usr/local/lib
+  /usr/lib
+  )
 
-FIND_LIBRARY (URDFDOM_WORLD_LIBRARY NAMES urdfdom_world PATHS
- 	/usr/local/include
- 	/usr/include
- 	)
+find_library (URDFDOM_WORLD_LIBRARY NAMES urdfdom_world
+  HINTS
+  ${URDFDOM_PC_LIBRARY_DIRS}
+  PATHS
+  /usr/local/lib
+  /usr/lib
+  )
 
-IF (NOT CONSOLE_BRIDGE_DIR OR NOT CONSOLE_BRIDGE_LIBRARY)
-	MESSAGE(ERROR "Could not find URDF: console_bridge not found")
-ELSE (NOT CONSOLE_BRIDGE_DIR OR NOT CONSOLE_BRIDGE_LIBRARY)
-	SET (CONSOLE_BRIDGE_FOUND TRUE)
-ENDIF (NOT CONSOLE_BRIDGE_DIR OR NOT CONSOLE_BRIDGE_LIBRARY)
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (URDF DEFAULT_MSG
+  CONSOLE_BRIDGE_DIR
+  CONSOLE_BRIDGE_LIBRARY
+  URDFDOM_HEADERS_DIR
+  URDFDOM_DIR
+  URDFDOM_MODEL_LIBRARY
+  URDFDOM_WORLD_LIBRARY
+  )
 
-IF (NOT URDFDOM_HEADERS_DIR)
-	MESSAGE(ERROR "Could not find URDF: urdfdom_headers not found")
-ELSE (NOT URDFDOM_HEADERS_DIR)
-	SET (URDFDOM_HEADERS_FOUND TRUE)
-ENDIF (NOT URDFDOM_HEADERS_DIR)
+if (URDF_FOUND)
+  set (CONSOLE_BRIDGE_FOUND TRUE)
+  set (URDFDOM_HEADERS_FOUND TRUE)
+  set (URDFDOM_FOUND TRUE)
+  set (URDF_INCLUDE_DIRS
+    ${CONSOLE_BRIDGE_DIR}
+    ${URDFDOM_HEADERS_DIR}
+    ${URDFDOM_DIR}
+    )
+  set (URDF_LIBRARIES
+    ${CONSOLE_BRIDGE_LIBRARY}
+    ${URDFDOM_WORLD_LIBRARY}
+    ${URDFDOM_MODEL_LIBRARY}
+    )
+endif()
 
-IF (NOT URDFDOM_DIR OR NOT URDFDOM_MODEL_LIBRARY OR NOT URDFDOM_WORLD_LIBRARY)
-	MESSAGE(ERROR "Could not find URDF: urdfdom_model or urdfdom_world library not found")
-ELSE (NOT URDFDOM_DIR OR NOT URDFDOM_MODEL_LIBRARY OR NOT URDFDOM_WORLD_LIBRARY)
-	SET (URDFDOM_FOUND TRUE)
-ENDIF (NOT URDFDOM_DIR OR NOT URDFDOM_MODEL_LIBRARY OR NOT URDFDOM_WORLD_LIBRARY)
-
-IF (CONSOLE_BRIDGE_FOUND AND URDFDOM_HEADERS_FOUND AND URDFDOM_FOUND)
-	SET (URDF_FOUND TRUE)
-ENDIF (CONSOLE_BRIDGE_FOUND AND URDFDOM_HEADERS_FOUND AND URDFDOM_FOUND)
-
-IF (URDF_FOUND)
-   IF (NOT URDF_FIND_QUIETLY)
-		 MESSAGE(STATUS "Found URDF console_bridge: ${CONSOLE_BRIDGE_LIBRARY}")
-		 MESSAGE(STATUS "Found URDF urdfdom_headers: ${URDFDOM_HEADERS_DIR}")
-		 MESSAGE(STATUS "Found URDF urdfdom: ${URDFDOM_LIBRARY}")
-  ENDIF (NOT URDF_FIND_QUIETLY)
-	SET (URDF_INCLUDE_DIRS
-		${CONSOLE_BRIDGE_DIR}
-		${URDFDOM_HEADERS_DIR}
-		${URDFDOM_DIR}
-		)
-	SET (URDF_LIBRARIES
-		${CONSOLE_BRIDGE_LIBRARY}
-		${URDFDOM_WORLD_LIBRARY}
-		${URDFDOM_MODEL_LIBRARY}
-		)
-	MESSAGE (STATUS "URDF Libraries: ${URDF_LIBRARIES}")
-ELSE (URDF_FOUND)
-   IF (URDF_FIND_REQUIRED)
-      MESSAGE(FATAL_ERROR "Could not find URDF")
-   ENDIF (URDF_FIND_REQUIRED)
-ENDIF (URDF_FOUND)
-
-MARK_AS_ADVANCED (
-	${URDF_INCLUDE_DIRS}
-	${URDF_LIBRARIES}
-	)
+mark_as_advanced (
+  CONSOLE_BRIDGE_DIR
+  CONSOLE_BRIDGE_LIBRARY
+  URDFDOM_HEADERS_DIR
+  URDFDOM_DIR
+  URDFDOM_MODEL_LIBRARY
+  URDFDOM_WORLD_LIBRARY
+  )

--- a/examples/bouncingBall/CMake/FindIPOPT.cmake
+++ b/examples/bouncingBall/CMake/FindIPOPT.cmake
@@ -1,39 +1,57 @@
-SET (IPOPT_FOUND FALSE)
+find_package (Ipopt CONFIG QUIET)
 
+if (Ipopt_FOUND AND NOT IPOPT_FOUND)
+  foreach (_ipopt_target Ipopt::ipopt ipopt::ipopt ipopt)
+    if (TARGET ${_ipopt_target})
+      set (IPOPT_LIBRARY ${_ipopt_target})
+      if (NOT IPOPT_INCLUDE_DIR)
+        get_target_property (IPOPT_INCLUDE_DIR ${_ipopt_target} INTERFACE_INCLUDE_DIRECTORIES)
+      endif()
+    endif()
+  endforeach()
 
-UNSET( IPOPT_INCLUDE_DIR              CACHE)   
-UNSET( IPOPT_LIBRARY                  CACHE)    
+  if (NOT IPOPT_INCLUDE_DIR AND Ipopt_INCLUDE_DIRS)
+    list (GET Ipopt_INCLUDE_DIRS 0 IPOPT_INCLUDE_DIR)
+  endif()
+  if (NOT IPOPT_LIBRARY AND Ipopt_LIBRARIES)
+    list (GET Ipopt_LIBRARIES 0 IPOPT_LIBRARY)
+  endif()
+endif()
 
-FIND_PATH (IPOPT_INCLUDE_DIR coin/IpTNLP.hpp
-  PATHS 
+find_package (PkgConfig QUIET)
+if (PKG_CONFIG_FOUND)
+  pkg_check_modules (IPOPT_PC QUIET ipopt)
+endif()
+
+find_path (IPOPT_INCLUDE_DIR IpTNLP.hpp
+  HINTS
+  ${IPOPT_PC_INCLUDE_DIRS}
+  PATHS
   ${CUSTOM_IPOPT_PATH}/include
+  PATH_SUFFIXES
+  coin
+  coin-or
   )
 
-FIND_LIBRARY (IPOPT_LIBRARY ipopt
+find_library (IPOPT_LIBRARY ipopt
+  HINTS
+  ${IPOPT_PC_LIBRARY_DIRS}
   PATHS
   ${CUSTOM_IPOPT_PATH}/lib
   )
 
-IF (IPOPT_INCLUDE_DIR AND IPOPT_LIBRARY)
-  SET (IPOPT_FOUND TRUE)
-ELSE(IPOPT_INCLUDE_DIR AND IPOPT_LIBRARY)
-  IF(IPOPT_FIND_REQUIRED)
-    MESSAGE (SEND_ERROR " Could not find IPOPT.")
-    MESSAGE (SEND_ERROR " Try setting CUSTOM_IPOPT_PATH in FindIPOPT.cmake force CMake to use the desired directory.")
-  ELSE(IPOPT_FIND_REQUIRED)
-    MESSAGE (STATUS " Could not find IPOPT.")
-    MESSAGE (STATUS " Try setting CUSTOM_IPOPT_PATH in FindIPOPT.cmake force CMake to use the desired directory.")
-  ENDIF(IPOPT_FIND_REQUIRED)
-ENDIF (IPOPT_INCLUDE_DIR AND IPOPT_LIBRARY)
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (IPOPT DEFAULT_MSG
+  IPOPT_LIBRARY
+  IPOPT_INCLUDE_DIR
+  )
 
-IF (IPOPT_FOUND)
-   IF (NOT IPOPT_FIND_QUIETLY)
-      MESSAGE(STATUS "Found IPOPT: ${IPOPT_LIBRARY}")
-   ENDIF (NOT IPOPT_FIND_QUIETLY)
+if (IPOPT_FOUND)
+  set (IPOPT_LIBRARIES ${IPOPT_LIBRARY})
+  set (IPOPT_INCLUDE_DIRS ${IPOPT_INCLUDE_DIR})
+endif()
 
-ENDIF (IPOPT_FOUND)
-
-MARK_AS_ADVANCED (
+mark_as_advanced (
   IPOPT_INCLUDE_DIR
   IPOPT_LIBRARY
   )

--- a/examples/casadi_simple/FindCasadi.cmake
+++ b/examples/casadi_simple/FindCasadi.cmake
@@ -10,11 +10,46 @@ if (Casadi_INCLUDE_DIR)
   set (Casadi_FIND_QUIETLY TRUE)
 endif (Casadi_INCLUDE_DIR)
 
-find_path (Casadi_INCLUDE_DIR "casadi.hpp" 
-    PATHS ${CMAKE_INSTALL_PREFIX}/include/casadi ${CMAKE_INSTALL_PREFIX}/Library/include/casadi
+find_package (Casadi CONFIG QUIET)
+if (NOT Casadi_FOUND)
+  find_package (casadi CONFIG QUIET)
+  if (casadi_FOUND)
+    set (Casadi_FOUND TRUE)
+  endif()
+endif()
+
+foreach (_casadi_target Casadi::casadi casadi::casadi casadi)
+  if (TARGET ${_casadi_target})
+    set (Casadi_LIBRARY ${_casadi_target})
+    if (NOT Casadi_INCLUDE_DIR)
+      get_target_property (Casadi_INCLUDE_DIR ${_casadi_target} INTERFACE_INCLUDE_DIRECTORIES)
+    endif()
+  endif()
+endforeach()
+
+if (NOT Casadi_INCLUDE_DIR AND Casadi_INCLUDE_DIRS)
+  list (GET Casadi_INCLUDE_DIRS 0 Casadi_INCLUDE_DIR)
+endif()
+if (NOT Casadi_INCLUDE_DIR AND casadi_INCLUDE_DIRS)
+  list (GET casadi_INCLUDE_DIRS 0 Casadi_INCLUDE_DIR)
+endif()
+if (NOT Casadi_LIBRARY AND Casadi_LIBRARIES)
+  list (GET Casadi_LIBRARIES 0 Casadi_LIBRARY)
+endif()
+if (NOT Casadi_LIBRARY AND casadi_LIBRARIES)
+  list (GET casadi_LIBRARIES 0 Casadi_LIBRARY)
+endif()
+
+find_path (Casadi_INCLUDE_DIR "casadi.hpp"
+    PATHS
+    ${CMAKE_INSTALL_PREFIX}/include/casadi
+    ${CMAKE_INSTALL_PREFIX}/Library/include/casadi
+    /usr/local/include/casadi
+    /usr/include/casadi
 )
 find_library (Casadi_LIBRARY NAMES casadi 
     PATHS ${CMAKE_INSTALL_PREFIX}/lib ${CMAKE_INSTALL_PREFIX}/Library/lib
+    /usr/lib
 )
 
 # handle the QUIETLY and REQUIRED arguments and set Casadi_FOUND to TRUE if
@@ -24,6 +59,5 @@ find_package_handle_standard_args (Casadi DEFAULT_MSG
     Casadi_LIBRARY
     Casadi_INCLUDE_DIR
 )
-
 
 


### PR DESCRIPTION
## Summary
- Let FindCasadi consume CasADi CMake config packages and exported targets before falling back to manual include/library searches.
- Update FindIPOPT to preserve user-provided cache values, support Ipopt config targets, and use pkg-config hints when available.
- Update FindURDF to use pkg-config hints for console_bridge, urdfdom_headers, and urdfdom while preserving existing URDF_* variables.
- Keep the copied example find modules in sync for CasADi and IPOPT.

## Validation
- Ran FindCasadi.cmake, FindIPOPT.cmake, and FindURDF.cmake in CMake script mode without the optional dependencies installed.
- Configured the core project with optional dependency addons disabled.